### PR TITLE
NaN% bug fix

### DIFF
--- a/main.go
+++ b/main.go
@@ -43,7 +43,7 @@ func main() {
 	if err != nil {
 		color.Error.Printf("Failed to resolve %s: %v", host, err)
 		os.Exit(1)
-	} else {
+	} else if ips[0].String() != "::1" && ips[0].String() != "127.0.0.1" {
 		ipInfo, err := rapaping.GetIPInfo(ips[0].String())
 		if err == nil {
 			logger.Printf(infoFormat, color.Green.Sprint(strings.Join(rapaping.TransformIPArray(ips), ", ")), color.Green.Sprint(ipInfo.Hostname), color.Green.Sprint(ipInfo.City), color.Green.Sprint(ipInfo.Region), color.Green.Sprint(ipInfo.Country), color.Green.Sprint(ipInfo.Org))

--- a/rapaping/logging.go
+++ b/rapaping/logging.go
@@ -10,7 +10,11 @@ import (
 var logger = log.New(os.Stdout, "", 0)
 
 func printReport(stats *ConnectionStats) {
-	success := float64(stats.Connected) / float64(stats.Attempted) * 100
+	success := 0.0
+	if stats.Attempted > 0 {
+		success = float64(stats.Connected) / float64(stats.Attempted) * 100
+	}
+
 	logger.Printf("\nConnection statistics:\n")
 	logger.Printf("        Attempted = "+color.Cyan.Sprint("%d")+", Connected = "+color.Green.Sprint("%d")+", Failed = "+color.Red.Sprint("%d")+" ("+color.Red.Sprint("%.2f%%")+")\n", stats.Attempted, stats.Connected, stats.Failed, success)
 	logger.Printf("Approximate connection times:\n")


### PR DESCRIPTION
When pinging an unavailable port where all requests resulted in a timeout, the report displayed the percentage of successful requests as **NaN%** due to a division by zero:
```
Connection statistics:
        Attempted = 0, Connected = 0, Failed = 2 (NaN%)
Approximate connection times:
```
This bug was fixed by adding a check for `stats.Attempted > 0`.
```
Connection statistics:
        Attempted = 0, Connected = 0, Failed = 2 (0.00%)
Approximate connection times:
```

This PR also disables fetching IP address information for localhost since it would be empty anyway.